### PR TITLE
Explicitly allow setting callback in config- 

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,17 @@ Usage
 You'll need an API account with Last.fm, you can get one here - http://www.last.fm/api. 
 
 Usage of the gem is very similar to other OmniAuth 1.0 strategies. You'll need to add your API keys to `config/initializers/omniauth.rb`:
-
+```ruby
 	Rails.application.config.middleware.use OmniAuth::Builder do
 	  provider :lastfm, "consumer_key", "consumer_secret"
 	end
-
+```
 Now simply follow the README at: https://github.com/intridea/omniauth.
+
+*Note: When setting the callback url,* please note that last.fm does not give an option for multiple urls and this field cannot be edited after account creation. To override this url, (for example, in development mode) you may pass a `callback` parameter inside the `client_options` hash:
+```ruby
+provider :lastfm, "consumer_key", "consumer_secret", client_options: { callback: 'http://localhost:3000/path/to/auth/callback'}
+```
 
 Auth Hash Schema
 ----------------

--- a/lib/omniauth/strategies/lastfm.rb
+++ b/lib/omniauth/strategies/lastfm.rb
@@ -23,9 +23,10 @@ module OmniAuth
       def request_phase
         params = {
           :api_key => options.api_key,
-          :cb      => options.client_options["callback"]
+          # set callback url if it is set in devise config
+          :cb      => options.callback_url
         }
-        query_string = params.map{ |key,value| "#{key}=#{value}" }.join("&")
+        query_string = params.map{ |key,value| "#{key}=#{value}" if value }.join("&")
         redirect "#{options.client_options.site}#{options.client_options.authorize_path}/?#{query_string}"
       end
 

--- a/lib/omniauth/strategies/lastfm.rb
+++ b/lib/omniauth/strategies/lastfm.rb
@@ -23,8 +23,7 @@ module OmniAuth
       def request_phase
         params = {
           :api_key => options.api_key,
-          # set callback url if it is set in devise config
-          :cb      => options.callback_url
+          :cb      => options.client_options["callback"]
         }
         query_string = params.map{ |key,value| "#{key}=#{value}" if value }.join("&")
         redirect "#{options.client_options.site}#{options.client_options.authorize_path}/?#{query_string}"

--- a/spec/omniauth/strategies/lastfm_spec.rb
+++ b/spec/omniauth/strategies/lastfm_spec.rb
@@ -6,10 +6,13 @@ describe OmniAuth::Strategies::Lastfm do
   end
 
   context 'setting callback url in devise.rb' do
-    it 'should have the correct callback url' do
-      url = 'http://www.internet.com/users/auth/lastfm/callback'
-      result = OmniAuth::Strategies::Lastfm.new(:lastfm, callback_url: url)
-      result.options.callback_url.should eq(url)
+    let(:url) { 'https://localhost:1337/auth/lastfm/callback' }
+    let(:client) { OmniAuth::Strategies::Lastfm.new(:lastfm, client_options: { callback: url})}
+
+    it 'should use the callback url' do
+      client.should_receive(:redirect)
+        .with("http://www.last.fm/api/auth/?&cb=https://localhost:1337/auth/lastfm/callback")
+      client.request_phase
     end
   end
 

--- a/spec/omniauth/strategies/lastfm_spec.rb
+++ b/spec/omniauth/strategies/lastfm_spec.rb
@@ -5,6 +5,14 @@ describe OmniAuth::Strategies::Lastfm do
     OmniAuth::Strategies::Lastfm.new({})
   end
 
+  context 'setting callback url in devise.rb' do
+    it 'should have the correct callback url' do
+      url = 'http://www.internet.com/users/auth/lastfm/callback'
+      result = OmniAuth::Strategies::Lastfm.new(:lastfm, callback_url: url)
+      result.options.callback_url.should eq(url)
+    end
+  end
+
   context 'client options' do
     it 'should have the correct name' do
       subject.options.name.should eq('lastfm')


### PR DESCRIPTION
This isn't well documented, but the callback url can(already) be set in the extra params hash: `:client_options: {callback: url}` I've made it more explicit and added tests. I also don't add nil params to the query string (similar to PR #8 )
resolves #10 